### PR TITLE
Changed regex to stop https:// URIs being discarded.

### DIFF
--- a/DecodeShortURLs.pm
+++ b/DecodeShortURLs.pm
@@ -283,7 +283,7 @@ sub parsed_metadata {
         # shortener to force this plug-in to follow a link that *isn't* on
         # the list of shorteners; we enforce that the shortener must be the
         # base URI and that a path must be present.
-        if ($uri !~ /^http:\/\/(?:www\.)?$_\/.+$/i) {
+        if ($uri !~ /^https?:\/\/(?:www\.)?$_\/.+$/i) {
           dbg("Discarding URI: $uri");
           next;
         }


### PR DESCRIPTION
Hi,

We had an Apple ID phishing mail through this morning - and while I was in the process of giving the SpamAssassin a kicking, I saw that the DecodeShortURLs plugin was discarding "https://tr.im/something"

So I altered the regex to take https into account, and suddenly the same mail scored 23.6 due to having blacklisted URIs in it ;)

Best Regards,
Nick.